### PR TITLE
Rename `splash-page` repo to `website`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "treshold-splash-page",
+  "name": "threshold-website",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: github
-  repo: threshold-network/splash-page
+  repo: threshold-network/website
   site_domain: threshold.network
   open_authoring: true
 


### PR DESCRIPTION
We're renaming some of the repositories in the `threshold-network` organization. One of them is `splash-page` repo, which will be renamed to `website`. We need to update the references of the old name.

⚠️ We should merge this PR roughly at the same time when we'll actually change the repo names in GitHub.