### PR TITLE
Fix layout on the ecosystem page

### DIFF
--- a/src/content/pages/ecosystem/index.md
+++ b/src/content/pages/ecosystem/index.md
@@ -53,12 +53,12 @@ projectsAndTools:
       - label: project
     date: 2023-01-31
     buttons:
-      - label: Learn More
-        url: https://docs.threshold.network/applications/tbtc-v2/
-        variant: EXTERNAL_OUTLINE
       - label: Go to App
         url: https://dashboard.threshold.network/tBTC/mint/
         variant: EXTERNAL_SOLID
+      - label: Learn More
+        url: https://docs.threshold.network/applications/tbtc-v2/
+        variant: EXTERNAL_OUTLINE
   - image: /images/thusd.svg
     title: thUSD
     description: thUSD is a stablecoin soft-pegged against USD and backed by ETH and tBTC as collaterals.
@@ -66,12 +66,12 @@ projectsAndTools:
       - label: project
     date: 2023-03-19
     buttons:
-      - label: Learn More
-        url: https://docs.threshold.network/applications/threshold-usd
-        variant: EXTERNAL_OUTLINE
       - label: Go to App
         url: https://app.thresholdusd.org/
         variant: EXTERNAL_SOLID
+      - label: Learn More
+        url: https://docs.threshold.network/applications/threshold-usd
+        variant: EXTERNAL_OUTLINE
   - image: /images/taco.svg
     title: TACo
     description: Threshold Access Control enables end-to-end encrypted data sharing and communication.

--- a/src/templates/ecosystem-page/ResourcesSection.tsx
+++ b/src/templates/ecosystem-page/ResourcesSection.tsx
@@ -76,8 +76,8 @@ const ResourcesExtendedCard: FC<ResourcesCardProps> = ({
             flexDirection="row"
             alignItems="center"
             justifyContent="center"
-            gap={6}
-            px={{ base: 8, md: 16 }}
+            gap={{ base: 10, md: 6 }}
+            px={{ base: 10, md: 16 }}
             py={20}
             backgroundImage={backgroundResources}
             backgroundRepeat="no-repeat"
@@ -92,7 +92,7 @@ const ResourcesExtendedCard: FC<ResourcesCardProps> = ({
               Threshold Blog
             </H3>
           </Flex>
-          <Stack spacing={7} pl={16} pr={20} py={10}>
+          <Stack spacing={7} px={{ base: 10, md: 20 }} py={10}>
             <H5 noOfLines={2}>{title}</H5>
             <BodyLg as="div" color="gray.400" noOfLines={3}>
               {description}


### PR DESCRIPTION
## Description

Fixed layout of the ecosystem page, a small adjustment in the spacing of social elements, and inverted order of "Projects and Tools" section.

- [x]  [Refactor ecosystem buttons order in content file](https://github.com/threshold-network/website/commit/8aab31412f96940dd5e1a04fd47a41447a9d68dd)
- [x]  [Refactor ecosystem social section padding](https://github.com/threshold-network/website/commit/70de12d42dc1c799cbc045eeb5e9c90009c1616b)

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] Fix on layout (Breaking/Non-breaking Change)

## Issue (if applicable)

Based on Sorin's comments on PR94: https://github.com/threshold-network/website/pull/94#issuecomment-1719718965

## Testing

Please outline all testing steps
1. Clone the repo - git clone https://github.com/threshold-network/website.git
2. Install dependencies - yarn install
3. Run the app - yarn start