### PR TITLE
Fix error that occured when updating the home page by admin

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -355,11 +355,6 @@ collections:
                             },
                           ],
                       },
-                      {
-                        label: Posthog Label,
-                        name: posthogLabel,
-                        widget: string,
-                      },
                     ],
                 }
           - label: "Token Holder Role"


### PR DESCRIPTION
There is an error when we try to update the home page through admin panel:

```
Oops, you've missed a required field. Please complete before saving.
```

<details>
<summary>Screenshot</summary>

<img width="415" alt="image" src="https://github.com/threshold-network/website/assets/40306834/8153ab49-1b09-4b2e-8392-2719fcb900f8">


</details>

It happens, because the `posthogLabel` field was required for Liquidity Provider Role section and it is not set by default in `stc/content/pages/index.md` file. The posthog label for this button is not needed anyway so it was probably added there by mistake in #70.

This PR removes that unnecessary field from the Liquidity Provider Roles buttons.