### PR TITLE
Add thUSD links to banner and menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ yarn start
 Open http://localhost:8000 to view it in the browser.
 
 The page will reload if you make edits.
+
+### Contributor Notes
+
+#### `@shoegazer_`
+* Had to do the following to get the above instructions to work:
+> First thing I would do is to lock the dependencies by removing all "^" from the package.json file. 
+After this, would install the dependencies using node version 18: `nvm use 18` and `yarn install`
+to build, I would use node version 16: `nvm use 16, yarn build and yarn start`
+
+* Tried the above on Windows and didn't work -- on Linux (Ubuntu) it did
+
+Filed https://github.com/threshold-network/website/issues/114

--- a/src/content/components/announcement-banner.md
+++ b/src/content/components/announcement-banner.md
@@ -3,4 +3,4 @@ template: announcement
 title: Announcement
 ---
 
-Maximize your BTC in DeFi. <a href="https://dashboard.threshold.network/tBTC/mint" target="_blank" rel="noopener noreferrer">Mint tBTC now</a>
+Maximize your BTC in DeFi. <a href="https://dashboard.threshold.network/tBTC/mint" target="_blank" rel="noopener noreferrer">Mint tBTC now</a> and use tBTC as collateral for <a href="https://thresholdusd.org/" target="_blank" rel="noopener noreferrer">thUSD stablecoin</a>

--- a/src/content/components/nav-bar.md
+++ b/src/content/components/nav-bar.md
@@ -44,6 +44,8 @@ nav_items:
 menu_buttons:
   - label: tBTC dApp
     url: https://dashboard.threshold.network/tBTC
+  - label: thUSD dApp
+    url: https://app.thresholdusd.org
 social_links:
   - label: Twitter
     url: https://twitter.com/TheTNetwork


### PR DESCRIPTION
Added links to thUSD to Threshold Network's front page.  

This is implemented in the same pattern as the tBTC links on the front page:
- add thUSD text and link to the announcement banner
- add thUSD app link to the nav-bar

Additionally I added some contributor notes to the README since the original README instructions
didn't work for me.
