### PR TITLE
Add thUSD links to main threshold.network page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ yarn start
 Open http://localhost:8000 to view it in the browser.
 
 The page will reload if you make edits.
+
+### Contributor Notes
+
+#### `@shoegazer_`
+* Had to do the following to get the above instructions to work:
+> First thing I would do is to lock the dependencies by removing all "^" from the package.json file. 
+After this, would install the dependencies using node version 18: `nvm use 18` and `yarn install`
+to build, I would use node version 16: `nvm use 16, yarn build and yarn start`
+
+* Tried the above on Windows and didn't work -- on Linux (Ubuntu) it did
+
+Filed https://github.com/threshold-network/website/issues/114
+

--- a/src/content/components/announcement-banner.md
+++ b/src/content/components/announcement-banner.md
@@ -3,4 +3,4 @@ template: announcement
 title: Announcement
 ---
 
-Maximize your BTC in DeFi. <a href="https://dashboard.threshold.network/tBTC/mint" target="_blank" rel="noopener noreferrer">Mint tBTC now</a>
+Maximize your BTC in DeFi. <a href="https://dashboard.threshold.network/tBTC/mint" target="_blank" rel="noopener noreferrer">Mint tBTC now</a> and use tBTC as collateral for <a href="https://thresholdusd.org/" target="_blank" rel="noopener noreferrer">thUSD stablecoin</a>

--- a/src/content/components/nav-bar.md
+++ b/src/content/components/nav-bar.md
@@ -44,6 +44,8 @@ nav_items:
 menu_buttons:
   - label: tBTC dApp
     url: https://dashboard.threshold.network/tBTC
+  - label: thUSD dApp
+    url: https://app.thresholdusd.org
 social_links:
   - label: Twitter
     url: https://twitter.com/TheTNetwork


### PR DESCRIPTION
Add links to [thUSD ](https://thresholdusd.org) and the [thUSD app](https://app.thresholdusd.org) to the threshold.network front page.

The change simply copies the pattern for tBTC in the nav_bar and announcement components and updates text/links appropriately.

Additionally, I added some notes to the README because the instructions didn't work for me as-is.

Screenshot with change:
![image](https://github.com/threshold-network/website/assets/157436350/6b3385a6-f550-4071-a3bc-9ac7d70372ad)
