### PR TITLE
Add gatsby prefix to subgraph api key env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn build:prefixed
         env:
           PUBLIC_URL: /${{ github.head_ref }}
+          GATSBY_SUBGRAPH_API_KEY: ${{ secrets.SUBGRAPH_API_KEY }}
 
       - name: Build
         if: github.event_name == 'push'
@@ -46,7 +47,7 @@ jobs:
           POSTHOG_HOSTNAME_HTTP: ${{ secrets.MAINNET_POSTHOG_HOSTNAME_HTTP }}
           GATSBY_GTM_SUPPORT: true
           GATSBY_GTM_ID: ${{ secrets.GTM_ID }}
-          SUBGRAPH_API_KEY: ${{ secrets.SUBGRAPH_API_KEY }}
+          GATSBY_SUBGRAPH_API_KEY: ${{ secrets.SUBGRAPH_API_KEY }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/src/config/subgraph.ts
+++ b/src/config/subgraph.ts
@@ -4,4 +4,4 @@ export const T_NETWORK_SUBGRAPH_URL =
 export const T_NETWORK_SUBGRAPH_ID =
   "5TJAMbsRwm1avUTV4CofaLT4apfQoAiNcysEit9BWr6R"
 
-export const TBTC_SUBGRAPH_URL = `https://gateway-arbitrum.network.thegraph.com/api/${process.env.SUBGRAPH_API_KEY}/subgraphs/id/DETCX5Xm6tJfctRcZAxhQB9q3aK8P4BXLbujHmzEBXYV`
+export const TBTC_SUBGRAPH_URL = `https://gateway-arbitrum.network.thegraph.com/api/${process.env.GATSBY_SUBGRAPH_API_KEY}/subgraphs/id/DETCX5Xm6tJfctRcZAxhQB9q3aK8P4BXLbujHmzEBXYV`


### PR DESCRIPTION
## Description

- [x] [add gatsby prefix to subgraph api key env variable](https://github.com/threshold-network/website/pull/125/commits/4141a4c74b7bffe8fcedb8943e452d9b301f946c)

## Notice

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] Chore Fix

## Testing

Please outline all testing steps
1. Clone the repo - git clone https://github.com/threshold-network/website.git
2. Install dependencies - yarn install
3. Build the app - yarn build
4. Run the app - yarn start