### PR TITLE
Update version of `upload-artifact` and `dowload-artifact` to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           GATSBY_GTM_ID: ${{ secrets.GTM_ID }}
           GATSBY_SUBGRAPH_API_KEY: ${{ secrets.SUBGRAPH_API_KEY }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build
           path: public
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Deploy PR to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Deploy build to GCP
         uses: thesis/gcp-storage-bucket-action@v3.1.0


### PR DESCRIPTION
The `v3` of the `actions/upload-artifact` and `actions/download-artifact` actions got
[deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) causing failure of workflow execution. We're upgrading to `v4` of the actions. Although there are some breaking changes in `v4` compared to `v3`, they do not affect our setup.